### PR TITLE
Remove the unused id from the users_tokens

### DIFF
--- a/Google.json
+++ b/Google.json
@@ -3040,7 +3040,6 @@
                     }
                 },
                 "resources": {
-                    "id": "string*",
                     "clientId": "string*",
                     "scopes[]": "string*",
                     "userKey": "string*",


### PR DESCRIPTION
The id field is not returned by google. This table should not have a key, providing an empty id field, suggests this table has a key, which it does not have.