### PR TITLE
Remove Warning for User Exists

### DIFF
--- a/Google.json
+++ b/Google.json
@@ -2036,9 +2036,6 @@
                             "password",
                             "familyName",
                             "givenName"
-                        ],
-                        "warning_only": [
-                            409
                         ]
                     },
                     "user_delete": {


### PR DESCRIPTION
Removing the warning only for user already exists. This should be an error