### PR TITLE
Add maxResults=1 to the test url

### DIFF
--- a/Google.json
+++ b/Google.json
@@ -3223,7 +3223,7 @@
             "authentication": "certificate",
             "call_handling": "google",
             "test_connection": {
-                "url": "www.googleapis.com/admin/directory/v1/users?customer=my_customer"
+                "url": "www.googleapis.com/admin/directory/v1/users?customer=my_customer&maxResults=1"
             }
         },
         "authOptions": {


### PR DESCRIPTION
Because of support for the Google Sheets API, NIM will not automatically add maxResults=1 to the test connection url.